### PR TITLE
Make copying character to clipboard super easy

### DIFF
--- a/templates/char.html
+++ b/templates/char.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block title %}{{ char_long_name }} - UTF8.XYZ{% endblock %}
 {% block body %}
-<style>h1 {font-size: 5em;}</style>
+<style>h1 {font-size: 5em; margin: 0; padding: 0.67em; cursor: pointer;}</style>
 <center>
-    <h1>{{ char_text }}</h1>
+    <h1 id="char">{{ char_text }}</h1>
     <b>{{ char_long_name }}</b></small><br>
     <div style="text-align: left; margin-left: 20%; width: 60%;">
     <ul>
@@ -58,5 +58,9 @@ addCopyTextToButton("copyHtml", "{{ char_html|safe }}");
 addCopyTextToButton("copyPython", "{{ backslashed(char_python) }}");
 addCopyTextToButton("copyUtf8", "{{ backslashed(char_utf8) }}");
 addCopyTextToButton("copyUtf16", "{{ backslashed(char_utf16) }}");
+
+document.getElementById("char").addEventListener('click', function (event) {
+    copyTextToClipboard("{{ backslashed(char_text)|safe }}");
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
I think this is great and I've been considering making something just like it for a while but you've already added pretty much everything I wanted so I'd love to just use your app instead. 👍 It's great!

The one thing I want most though is super simple copying. I often end up [here](https://fsymbols.com/signs/bullet-point/) or [here](https://copydashes.com/) and wanting to just click the character to put it in my clipboard.

Currently there's no indication that copy happened. If you want, I could add an indication of some sort, though I don't know what you'd most expect to happen visually. On [unicode.party](https://unicode.party/?query=sparkle) we use a little toaster-style  notification like this:

![image](https://user-images.githubusercontent.com/285352/174220987-8d569ca8-fbb3-47bb-967b-47d5da252547.png)

Personally I'd be fine without any notification, as I doubt folks would accidentally end up on this site and click and then be disappointed to lose their clipboard data. 🤷