### PR TITLE
Allow reverse lookups based on a character

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,6 +119,7 @@ def category_or_char(char):
         char_text=char_chr,
         char_html=f"&#{char_ord};",
         char_python=f"\\{'U' if len(code_point_hex) > 4 else 'u'}{code_point_hex}",
+        char_python2=f"\\N{{{name.replace('-', ' ')}}}",
         char_long_name=title(name),
         char_code_point=f"U+{code_point_hex}",
         char_utf8=encode_to_hex_bytes(char_chr, "utf-8"),

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import re
 import sqlite3
-from flask import Flask, Response, render_template, g, request, abort, send_file, redirect
+from flask import Flask, Response, render_template, g, request, abort, send_file, redirect, url_for
 
 app = Flask(__name__)
 categories = ["arrows", "currency"]
@@ -91,7 +91,7 @@ def category_or_char(char):
         except Exception:
             pass
         else:
-            return redirect(f"/{name}")
+            return redirect(url_for("category_or_char", char=name))
 
     db.execute("SELECT name, ordinal FROM chars WHERE name = ?;", (char,))
     try:

--- a/app.py
+++ b/app.py
@@ -1,6 +1,16 @@
 import re
 import sqlite3
-from flask import Flask, Response, render_template, g, request, abort, send_file, redirect, url_for
+from flask import (
+    Flask,
+    Response,
+    render_template,
+    g,
+    request,
+    abort,
+    send_file,
+    redirect,
+    url_for,
+)
 
 app = Flask(__name__)
 categories = ["arrows", "currency"]

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import re
 import sqlite3
-from flask import Flask, Response, render_template, g, request, abort, send_file
+from flask import Flask, Response, render_template, g, request, abort, send_file, redirect
 
 app = Flask(__name__)
 categories = ["arrows", "currency"]
@@ -82,6 +82,16 @@ def category_or_char(char):
             "SELECT name, ordinal FROM chars WHERE category = ?;",
             (char,),
         )
+
+    # Redirect single characters to their names
+    if len(char) == 1:
+        db.execute("SELECT name, ordinal FROM chars WHERE ordinal = ?;", (ord(char),))
+        try:
+            name, char_ord = db.fetchone()
+        except Exception:
+            pass
+        else:
+            return redirect(f"/{name}")
 
     db.execute("SELECT name, ordinal FROM chars WHERE name = ?;", (char,))
     try:

--- a/templates/char.html
+++ b/templates/char.html
@@ -11,6 +11,7 @@
         <li><button class="copyCodePoint">Copy</button> Code Point: {{ char_code_point }}</li>
         <li><button class="copyHtml">Copy</button> HTML: {{ char_html }} </li>
         <li><button class="copyPython">Copy</button> Python: {{ char_python }}</li>
+        <li><button class="copyPython2">Copy</button> Python: {{ char_python2 }}</li>
         <li><button class="copyUtf8">Copy</button> UTF-8: {{ char_utf8 }}</li>
         <li><button class="copyUtf16">Copy</button> UTF-16: {{ char_utf16 }}</li>
     </ul>
@@ -56,6 +57,7 @@ addCopyTextToButton("copyChar", "{{ backslashed(char_text)|safe }}");
 addCopyTextToButton("copyCodePoint", "{{ char_code_point }}");
 addCopyTextToButton("copyHtml", "{{ char_html|safe }}");
 addCopyTextToButton("copyPython", "{{ backslashed(char_python) }}");
+addCopyTextToButton("copyPython2", "{{ backslashed(char_python2) }}");
 addCopyTextToButton("copyUtf8", "{{ backslashed(char_utf8) }}");
 addCopyTextToButton("copyUtf16", "{{ backslashed(char_utf16) }}");
 </script>


### PR DESCRIPTION
Sometimes I end up with a character in my clipboard and I'd like to easily lookup its name and the `\u` code I'd need to type into Python to get the same character.

This adds a reverse lookup which redirects to the correct character name URL for that purpose.

Examples:

- https://utf8.xyz/— → https://utf8.xyz/em-dash
- https://utf8.xyz/→ → https://utf8.xyz/rightwards-arrow
- https://utf8.xyz/→ → https://utf8.xyz/rightwards-arrow
- https://utf8.xyz/• → https://utf8.xyz/bullet

It might be worth considering that this endpoint could do something more useful from the perspective of `curl` (printing `\u2192` or `\N{rightwards arrow}` maybe).