### PR TITLE
Add search box redirecting to appropriate URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from flask import (
     g,
     request,
     abort,
-    send_file,
     redirect,
     url_for,
 )
@@ -49,8 +48,10 @@ def cache_control_header(response: Response):
     return response
 
 
-@app.route("/", methods=["GET"])
+@app.route("/", methods=["GET", "POST"])
 def index():
+    if request.method == "POST":
+        return redirect(url_for("category_or_char", char=request.form.get("char")))
     return render_template("index.html")
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,10 @@
     a, a:visited, a:hover, a:active {
         color: inherit;
     }
+    input, button {
+        font-size: 1em;
+        padding: 0.25em;
+    }
     </style>
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,12 @@
 {% block body %}
 <h1>UTF8.XYZ</h1>
 <p>A quick web app for fetching Unicode characters without extra fluff</p>
+
+<form method="post">
+    <input type="text" name="char" placeholder="Search for a character" autofocus>
+    <button type="submit">Lookup character</button>
+</form>
+
 <h2>Features</h2>
 <ul>
     <li>Use the URL to build queries, will return matching results if more than one</li>


### PR DESCRIPTION
I may be attempting to slowly turn https://unicode.party. 😅 Feel free to stop me. 🛑

I'm not sure if this is in opposition to the way you expected this tool to be used, but I find that I use this in the browser quite often and searching from the homepage feels easier to me than searching via a URL.

This adds an input box and a button and the input box is focused on page load (so the user can start typing right away)

![image](https://user-images.githubusercontent.com/285352/178621456-3ec3c481-22a7-4d00-87cc-987ba02d1bc5.png)

Clicking the button or hitting "Enter" submits the form via a POST request and redirects to the correct page (https://utf8.xyz/rainbow in the case below)

![image](https://user-images.githubusercontent.com/285352/178621615-b5f6764d-70c0-4f03-9ca1-ea39f165a0e8.png)

Searching with spaces works already because spaces in URLs work. For example here's a search for "hand sign":

![image](https://user-images.githubusercontent.com/285352/178621946-3b92967d-63ec-4248-a105-dc4996e8439b.png)